### PR TITLE
Add project directory as a input

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,16 @@ steps:
       gluon-license: ${{ secrets.GLUON_LICENSE }} 
 ```
 
+In case, you have a multi-module setup, with `main-module` containing Gluon Application,
+`project-dir` can be specified:
+
+```yaml
+steps:
+- name: Gluon Build License
+    uses: gluonhq/gluon-build-license@v1
+    with:
+      gluon-license: ${{ secrets.GLUON_LICENSE }}
+      project-dir: main-module
+```
+
 * Configure GLUON_LICENSE in your repo secrets

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ steps:
 ```
 
 In case, you have a multi-module setup, with `main-module` containing Gluon Application,
-`project-dir` can be specified:
+`dir` can be specified:
 
 ```yaml
 steps:
@@ -25,7 +25,7 @@ steps:
     uses: gluonhq/gluon-build-license@v1
     with:
       gluon-license: ${{ secrets.GLUON_LICENSE }}
-      project-dir: main-module
+      dir: main-module
 ```
 
 * Configure GLUON_LICENSE in your repo secrets

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   gluon-license:
     required: true
     description: License provided by Gluon
-  dir:
+  project-dir:
     required: false
     description: Directory path to Gluon Application. Useful in multi-module project setup.
 runs:
   using: "composite"
   steps: 
-    - run: printf "${{ inputs.gluon-license }}" > "${{ inputs.dir }}"/src/main/resources/gluonmobile.license
+    - run: printf "${{ inputs.gluon-license }}" > "${{ inputs.project-dir }}"/src/main/resources/gluonmobile.license
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
 runs:
   using: "composite"
   steps: 
-    - run: printf "${{ inputs.gluon-license }}" > src/main/resources/gluonmobile.license
+    - run: printf "${{ inputs.gluon-license }}" > "${{ inputs.dir }}"/src/main/resources/gluonmobile.license
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,11 @@ inputs:
   gluon-license:
     required: true
     description: License provided by Gluon
-  project-dir:
+  dir:
     required: false
     description: Directory path to Gluon Application. Useful in multi-module project setup.
 runs:
   using: "composite"
   steps: 
-    - run: printf "${{ inputs.gluon-license }}" > "${{ inputs.project-dir }}"/src/main/resources/gluonmobile.license
+    - run: printf "${{ inputs.gluon-license }}" > "${{ inputs.dir }}"/src/main/resources/gluonmobile.license
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ branding:
 inputs:
   gluon-license:
     required: true
+    description: License provided by Gluon
+  dir:
+    required: false
+    description: Directory path to Gluon Application
 runs:
   using: "composite"
   steps: 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: License provided by Gluon
   dir:
     required: false
-    description: Directory path to Gluon Application
+    description: Directory path to Gluon Application. Useful in multi-module project setup.
 runs:
   using: "composite"
   steps: 


### PR DESCRIPTION
In multi-moudle project, the location of the license file will be `${project-directory}/src/main/resources`.